### PR TITLE
Adding embedded type definition files.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for ngraph.graph v0.0.14
+// Project: https://github.com/anvaka/ngraph.graph
+// Definitions by: Nathan Westlake <https://github.com/CorayThan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "ngraph.graph" {
+
+    type NodeId = string | number
+
+    interface Link {
+        id: string,
+        fromId: NodeId,
+        toId: NodeId,
+        data: any
+    }
+
+    interface Node {
+        id: NodeId,
+        links: Link[],
+        data: any
+    }
+
+    interface Coordinates {
+        x: number,
+        y: number
+    }
+
+    interface Graph {
+        addNode: (node: NodeId, nodeCoordinates: Coordinates) => Node
+        addLink: (from: NodeId, to: NodeId, data?: any) => Link
+        removeLink: (link: Link) => boolean
+        removeNode: (nodeId: NodeId) => boolean
+        getNode: (nodeId: NodeId) => Node | undefined
+        hasNode: (nodeId: NodeId) => Node | undefined
+        getLink: (fromNodeId: NodeId, toNodeId: NodeId) => Link | null
+        hasLink: (fromNodeId: NodeId, toNodeId: NodeId) => Link | null
+        getNodesCount: () => number
+        getLinksCount: () => number
+        getLinks: Link[]
+        forEachNode: (callbackPerNode: (node: Node) => void) => void
+        forEachLinkedNode: (nodeId: NodeId, callbackPerNode: (node: Node, link: Link) => void, oriented: boolean) => void
+        forEachLink: (callbackPerLink: (link: Link) => void) => void
+        beginUpdate: () => void
+        endUpdate: () => void
+        clear: () => void
+    }
+
+    export default function createGraph(options?: { multigraph: boolean }): Graph
+
+}


### PR DESCRIPTION
I created some type definition files for using your pathing library in a Typescript project, and wanted to see if we could embed them so others will have type definitions too, in the future.