### PR TITLE
Fix wrong type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,13 +20,8 @@ declare module "ngraph.graph" {
         data: any
     }
 
-    interface Coordinates {
-        x: number,
-        y: number
-    }
-
     interface Graph {
-        addNode: (node: NodeId, nodeCoordinates: Coordinates) => Node
+        addNode: (node: NodeId, data?: any) => Node
         addLink: (from: NodeId, to: NodeId, data?: any) => Link
         removeLink: (link: Link) => boolean
         removeNode: (nodeId: NodeId) => boolean


### PR DESCRIPTION
I think the second argument of `addNode` method is `data` rather than `nodeCoordinates`.
And it seems this library does NOT care about coordinates so I removed `Coordinates` interface as well.