### PR TITLE
Added useMap option to graph

### DIFF
--- a/perf/node-iteration.js
+++ b/perf/node-iteration.js
@@ -1,0 +1,37 @@
+var Benchmark = require('benchmark');
+
+var createGraph = require('../'),
+    numberOfNodes = 10000;
+
+var suite = new Benchmark.Suite();
+
+var graphWithOutMap = createGraph();
+var graphWithMap = createGraph({useMap: true});
+for (var i = 0; i < numberOfNodes; ++i) {
+  graphWithOutMap.addNode('hello' + i, i);
+  graphWithMap.addNode('hello' + i, i);
+}
+
+var sum1 = 0;
+var sum2 = 0;
+
+// add tests
+suite.add('graphWithOutMap', function() {
+  graphWithOutMap.forEachNode(function (node) {
+    sum1 += node.data;
+  });
+})
+.add('graphWithMap', function() {
+  graphWithMap.forEachNode(function (node) {
+    sum2 += node.data;
+  });
+})
+.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+.on('complete', function() {
+   console.log('Fastest is ' + this.filter('fastest').map("name"));
+//    console.log(sum1, sum2);
+})
+// run async
+.run({ 'async': true });

--- a/test/construction.js
+++ b/test/construction.js
@@ -87,7 +87,7 @@ test('it can add node with id similar to reserved prototype property', function(
 
   t.ok(graph.hasLink('watch', 'constructor'));
   t.equals(graph.getLinksCount(), 1, 'one link');
-  t.equal(iterated, 2, 'has two nodes');
+  t.equals(iterated, 2, 'has two nodes');
   t.end();
 });
 


### PR DESCRIPTION
Allow people to use maps instead of objects because
1. they are faster (755 ops/sec ±1.45% vs 6,462 ops/sec ±3.79%)
2. they allow you to use objects as keys.

I would say make it the default, but not all browsers support it. Maybe make it check to see it it's supported and automatically enable it.

 I made sure it passed all the tests.

PS, I love ngraph. I just started using it and it's awsome.