### PR TITLE
Adds oriented version of getLink and allow people to set default orientatidness

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ function createGraph(options) {
   if (typeof Map !== 'function') {
     // TODO: Should we polyfill it ourselves? We don't use much operations there..
     throw new Error('ngraph.graph requires `Map` to be defined. Please polyfill it before using ngraph');
-  } 
+  }
+
+  // Sets the default for if functions should be oriented or not.
+  if (options.oriented === undefined) options.oriented = false;
 
   var nodes = new Map();
   var links = [],
@@ -171,6 +174,7 @@ function createGraph(options) {
      * @param {Function(node, link)} callback Function to be called on all linked nodes.
      *   The function is passed two parameters: adjacent node and link object itself.
      * @param oriented if true graph treated as oriented.
+     *   Default to options.oriented.
      */
     forEachLinkedNode: forEachLinkedNode,
 
@@ -229,6 +233,8 @@ function createGraph(options) {
      *
      * @param {string} fromId link start identifier
      * @param {string} toId link end identifier
+     * @param {boolean} oriented if true graph treated as oriented.
+     *   Default to options.oriented.
      *
      * @returns link if there is one. null otherwise.
      */
@@ -415,7 +421,7 @@ function createGraph(options) {
     return true;
   }
 
-  function getLink(fromNodeId, toNodeId) {
+  function getLink(fromNodeId, toNodeId, oriented=options.oriented) {
     // TODO: Use sorted links to speed this up
     var node = getNode(fromNodeId),
       i;
@@ -425,7 +431,9 @@ function createGraph(options) {
 
     for (i = 0; i < node.links.length; ++i) {
       var link = node.links[i];
-      if (link.fromId === fromNodeId && link.toId === toNodeId) {
+      if (link.fromId === fromNodeId && link.toId === toNodeId
+          || oriented && link.fromId === toNodeId && link.toId === fromNodeId
+        ) {
         return link;
       }
     }
@@ -450,7 +458,7 @@ function createGraph(options) {
     }
   }
 
-  function forEachLinkedNode(nodeId, callback, oriented) {
+  function forEachLinkedNode(nodeId, callback, oriented=options.oriented) {
     var node = getNode(nodeId);
 
     if (node && node.links && typeof callback === 'function') {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function createGraph(options) {
   }
 
   // Sets the default for if functions should be oriented or not.
-  if (options.oriented === undefined) options.oriented = false;
+  if (options.oriented === undefined) options.oriented = true;
 
   var nodes = new Map();
   var links = [],
@@ -432,7 +432,7 @@ function createGraph(options) {
     for (i = 0; i < node.links.length; ++i) {
       var link = node.links[i];
       if (link.fromId === fromNodeId && link.toId === toNodeId
-          || oriented && link.fromId === toNodeId && link.toId === fromNodeId
+          || !oriented && link.fromId === toNodeId && link.toId === fromNodeId
         ) {
         return link;
       }

--- a/test/construction.js
+++ b/test/construction.js
@@ -1,6 +1,52 @@
 var test = require('tap').test,
   createGraph = require('..');
 
+test('getLink respects orientation', function(t) {
+  var graph = createGraph();
+  
+  var data = '413'
+
+  graph.addLink(1, 2, data)
+
+  t.equal( graph.getLink(1, 2).data, data, "should get the link")
+  t.notOk( graph.getLink(2, 1), "should not get the link")
+
+  t.equal( graph.getLink(1, 2, false).data, data, "should get the link")
+  t.equal( graph.getLink(2, 1, false).data, data, "should get the link")
+  
+  t.end()
+})
+
+test('createGraph uses orientation option', function(t) {
+  var orientatedGraph = createGraph({oriented: true});
+  var nonorientatedGraph = createGraph({oriented: false});
+
+  var data1 = "42"
+  var data2 = "2001"
+
+  orientatedGraph.addLink(1, 2, data1)
+  orientatedGraph.addLink(2, 3, data1)
+
+  nonorientatedGraph.addLink(1, 2, data1)
+  nonorientatedGraph.addLink(2, 3, data1)
+
+  t.equal( orientatedGraph.getLink(1, 2).data, data1, "should get the link")
+  t.notOk( orientatedGraph.getLink(2, 1), "should not get the link")
+
+  t.equal( nonorientatedGraph.getLink(1, 2).data, data1, "should get the link")
+  t.equal( nonorientatedGraph.getLink(2, 1).data, data1, "should get the link")
+
+  orientatedGraph.forEachLinkedNode(2, function(node, link) {
+    t.ok(link.toId === 3, 'Only 3 is connected to node 2, when traversal is oriented');
+  });
+
+  nonorientatedGraph.forEachLinkedNode(2, function(node, link) {
+    t.ok(link.toId === 3 || link.toId === 2, 'both incoming and outgoing links are visited');
+  });
+
+  t.end();
+})
+
 test('add node adds node', function(t) {
   var graph = createGraph();
   var customData = '31337';


### PR DESCRIPTION
I added an oriented param to `getLink` so that you can get links pointing either direction easier and makes it easier to see if two links are connected in either direction.  Even if they are connected in both direction it will only return one.

Allow people to set the default oriented parameter for using getLink and forEachLinkedNode by doing `createGraph({oriented: true})`.

I made some unit-testing for it.