### PR TITLE
Export all types from ngraph.graph module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,22 +5,24 @@
 
 declare module "ngraph.graph" {
     import { EventedType } from 'ngraph.events'
-    type NodeId = string | number
+    
+    export type NodeId = string | number
+    export type LinkId = string
 
-    interface Link<Data = any> {
-        id: string,
+    export interface Link<Data = any> {
+        id: LinkId,
         fromId: NodeId,
         toId: NodeId,
         data: Data
     }
 
-    interface Node<Data = any> {
+    export interface Node<Data = any> {
         id: NodeId,
         links: Link[],
         data: Data
     }
 
-    interface Graph<NodeData = any, LinkData = any> {
+    export interface Graph<NodeData = any, LinkData = any> {
         addNode: (node: NodeId, data?: NodeData) => Node<NodeData>
         addLink: (from: NodeId, to: NodeId, data?: LinkData) => Link<LinkData>
         removeLink: (link: Link<LinkData>) => boolean


### PR DESCRIPTION
Sometimes it is required to use the type of node or link (or the types of their identifiers). For example, to store them outside the graph. In addition, the type of the graph itself is also very useful.