### PR TITLE
Add method to find link by its id

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,11 @@ declare module "ngraph.graph" {
         getLink: (fromNodeId: NodeId, toNodeId: NodeId) => Link<LinkData> | undefined
 
         /**
+         * Returns a link by its id
+         */
+        getLinkById: (linkId: LinkId) => Link<LinkData> | undefined;
+
+        /**
          * Checks if link is present in the graph 
          */
         hasLink: (fromNodeId: NodeId, toNodeId: NodeId) => Link<LinkData> | undefined

--- a/index.js
+++ b/index.js
@@ -246,7 +246,16 @@ function createGraph(options) {
      *
      * @returns link if there is one; undefined otherwise.
      */
-    getLink: getLink
+    getLink: getLink,
+
+    /**
+     * Gets a link by its id.
+     *
+     * @param {string} linkId link identifier
+     *
+     * @returns link if there is one; undefined otherwise.
+     */
+    getLinkById: getLinkById
   };
 
   // this will add `on()` and `fire()` methods.
@@ -443,6 +452,11 @@ function createGraph(options) {
   function getLink(fromNodeId, toNodeId) {
     if (fromNodeId === undefined || toNodeId === undefined) return undefined;
     return links.get(makeLinkId(fromNodeId, toNodeId));
+  }
+
+  function getLinkById(linkId) {
+    if (linkId === undefined) return undefined;
+    return links.get(linkId);
   }
 
   function clear() {

--- a/test/construction.js
+++ b/test/construction.js
@@ -45,6 +45,13 @@ test('hasLink is the same as getLink', function () {
   expect(graph.getLink).toBe(graph.hasLink);
 });
 
+test('getLinkById gets link by id', function () {
+  var graph = createGraph();
+  var link = graph.addLink(1, 2);
+  var fetchedLink = graph.getLinkById(link.id);
+  expect(fetchedLink).toBe(link);
+});
+
 test('it considers uniqueLinkId as multigraph', function () {
   var options = {uniqueLinkId: true};
   createGraph(options);


### PR DESCRIPTION
This pr is a proposal to add the `getLinkById` method so it becomes possible to get a link by its id. It seems to work fine in my tests.

With this change it would be possible to get a link both by from-to NodeId and by LinkId:

```
var graph = createGraph();
var linkId = graph.addLink(1, 2).id; // no need to externally store the link, just its id
...
var link12 = graph.getLinkById(linkId); // link found by its id
```

Maybe this improvement also makes it possible to retrieve the links by id with multigraph option enabled, but I haven't tested this use case.

closes #48 